### PR TITLE
longer timeout for the http client

### DIFF
--- a/src/VestaCP.php
+++ b/src/VestaCP.php
@@ -38,7 +38,7 @@ class VestaCP
         if ($client == null) {
             $this->client = new Client([
                 'base_uri' => 'https://'.$server.':8083',
-                'timeout'  => 5.0,
+                'timeout'  => 15.0,
                 'headers'  => [
                     'User-Agent' => 'Made I.T. Vesta SDK V'.$this->version,
                     'Accept'     => 'application/json',


### PR DESCRIPTION
For some commands (eg. LE certificates generation), 5 seconds is too short and the operation ends up with a timeout.